### PR TITLE
remove deleted leftovers from list of files to package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,9 @@ jobs:
         inject_css_suggested.css
         inject_css_suggested_no_edit.css
         imageWorker.js
-        bg.jpg
         background.js
         entities.json
         uDarkEncoder.js
-        resolveIDKVars.js
         icons/
         Listeners.js
         contentScriptClass.js


### PR DESCRIPTION
Fix warning at release creation:
```
▸ Run mkdir -p release
	zip warning: name not matched: bg.jpg
	zip warning: name not matched: resolveIDKVars.js
  adding: manifest.json (deflated 50%)
```