### PR TITLE
optimize tab-pattern matching - fixes #206

### DIFF
--- a/popup/modules/tabutils.js
+++ b/popup/modules/tabutils.js
@@ -24,19 +24,21 @@ export async function searchTabIDMatchingPatterns(tab, patterns, remove_flags = 
             return pattern.split("#ud_")[0].trim();
         });
     }
-    let matchingPatterns = [];
-    for (let pattern of patterns) {
+    const matchingPatterns = await Promise.all(
+      patterns.map(async pattern => {
         try {
-            let matchingTabs = await browser.tabs.query({url: pattern}).catch(console.warn) || [];
-            matchingTabs = matchingTabs.filter(x => x.id == tab.id);
-            if (matchingTabs.length) {
-                matchingPatterns.push(pattern);
-            }
-        } catch (error) {
-            console.warn("Pattern matching error for", pattern, error);
+          let matchingTabs = await browser.tabs.query({ 
+            url: pattern, 
+            windowId: tab.windowId,
+            index: tab.index 
+          }).catch(console.warn);
+          return (matchingTabs.length ?? 0) > 0 ? pattern : null;
+        } catch (error2) {
+          console.warn("Pattern matching error for", pattern, error2);
         }
-    }
-    return matchingPatterns;
+      })
+    )
+    return matchingPatterns.filter(Boolean);
 }
 export async function getEmbedsOfTab(tab,filterfunction) {
     if (!tab || typeof tab.id === 'undefined') return [];


### PR DESCRIPTION
This PR focuses on optimizing the pattern matching against tabs to check if they are included or excluded, as with a large number of tabs open it gets progressively slow. (#206)

The final result is a **50x speedup** (which brings down the check time to ~20ms, almost unnoticeable).

## Why & Measurement

To start with, I timed the `searchTabIDMatchingPatterns` function by adding `performance.now()` calls and a console log.

Before this PR:
<img width="249" height="188" alt="image" src="https://github.com/user-attachments/assets/daa816c7-5e4b-4099-b559-37b0491498d1" />
_It was behaving faster than usual for me today, as mentioned in #206 it usually takes 5-6 seconds for the visual included/excluded to show in the popup._
_Note: I have ~1500 tabs open._

**Before: Average = 1076.29 ms**

## Methods:

### 1. Make `browser.tabs.query` more efficient by only matching the pattern against the current tab - identified completely by its `windowId` and `index`. Currently, it searches against all tabs and the complexity grows linearly (probably, depends on browser implementation) with the number of open tabs.

```diff
 let matchingTabs = browser.tabs.query({ 
   url: pattern,
+  windowId: tab.windowId,
+  index: tab.index
 })
-matchingTabs = matchingTabs.filter((x) => x.id == tab.id); // not required anymore
```
This PR changes this complexity to be `O(1)` by limiting the search scope to only the single tab we are interested in.

#### Effect
**After 1: Average = 60.72 ms** (17.7x speedup)

<img width="247" height="239" alt="image" src="https://github.com/user-attachments/assets/88137670-1f25-4b9f-a299-7c1cb259839e" />


### 2. Parallelize calls to `browser.tabs.query` across all patterns. This is sequential so the complexity also grows linearly with number of patterns.

```diff
-let matchingPatterns = [];
-for (let pattern of patterns) {
+const matchingPatterns = (await Promise.all(
+patterns.map(async pattern => {
     try {
     let matchingTabs = await browser.tabs.query({ url: pattern }).catch(console.warn) || [];
     matchingTabs = matchingTabs.filter((x) => x.id == tab.id);
-    if (matchingTabs.length) {
-      matchingPatterns.push(pattern);
-    }
+    return (matchingTabs.length ?? 0) > 0 ? pattern : null;
   } catch (error2) {
     console.warn("Pattern matching error for", pattern, error2);
   }
-}
+})
+)).filter(Boolean)
 return matchingPatterns;
```

This is still using the old query over all tabs, but is sending the requests for every pattern concurrently.

#### Effect
**After 2: Average = 497.67 ms** (2.2x speedup)

<img width="245" height="130" alt="image" src="https://github.com/user-attachments/assets/6de71a7d-063a-404c-aea6-9c5c84b2fecf" />


### Net Effect
**After 1+2: Average = 21.80 ms** (49.4x speedup)

<img width="245" height="280" alt="image" src="https://github.com/user-attachments/assets/0df6eb05-f621-43ad-ba36-bc306db394c9" />
