### PR TITLE
Add reusable Firefox compatibility audit

### DIFF
--- a/.github/workflows/firefox-compatibility-audit.yml
+++ b/.github/workflows/firefox-compatibility-audit.yml
@@ -73,13 +73,18 @@ jobs:
           )
 
           for item in "${files[@]}"; do
+            test -e "$item"
             mkdir -p "$package/$(dirname "$item")"
             cp -a "$item" "$package/$item"
           done
 
-          # The release workflow removes full-line // comments before packaging.
+          # Reproduce the manifest transformations from the release workflow.
           sed -i 's/^[[:space:]]*\/\/.*$//g' "$package/manifest.json"
+          sed -i \
+            's/{0a0f6dea-3957-4bb9-9eec-2ef2b9e5bcec}/{7c7f6dea-3957-4bb9-9eec-2ef2b9e5bcec}/g' \
+            "$package/manifest.json"
 
+          # Change only the desktop minimum under browser_specific_settings.gecko.
           python3 - "$package/manifest.json" "${{ matrix.minimum }}" <<'PY'
           import json
           import pathlib
@@ -156,3 +161,54 @@ jobs:
             ${{ runner.temp }}/UltimaDark-firefox-${{ matrix.minimum }}.zip
             ${{ runner.temp }}/firefox-${{ matrix.minimum }}-lint.json
             firefox-${{ matrix.minimum }}-lint.md
+
+  verify-package-delta:
+    name: Verify 115/128 package delta
+    needs: lint-release-package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: firefox-*-mozilla-lint
+          path: artifacts
+
+      - name: Prove packages differ only by desktop minimum
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir pkg115 pkg128
+          unzip -q artifacts/firefox-115.0-mozilla-lint/_temp/UltimaDark-firefox-115.0.zip -d pkg115
+          unzip -q artifacts/firefox-128.0-mozilla-lint/_temp/UltimaDark-firefox-128.0.zip -d pkg128
+
+          python3 <<'PY'
+          import json
+          import pathlib
+
+          left = pathlib.Path("pkg115")
+          right = pathlib.Path("pkg128")
+
+          left_files = sorted(p.relative_to(left) for p in left.rglob("*") if p.is_file())
+          right_files = sorted(p.relative_to(right) for p in right.rglob("*") if p.is_file())
+          if left_files != right_files:
+              raise SystemExit("The Firefox 115 and 128 packages do not contain the same files")
+
+          for relative in left_files:
+              if relative.as_posix() == "manifest.json":
+                  continue
+              if (left / relative).read_bytes() != (right / relative).read_bytes():
+                  raise SystemExit(f"Unexpected package difference: {relative}")
+
+          manifest115 = json.loads((left / "manifest.json").read_text(encoding="utf-8"))
+          manifest128 = json.loads((right / "manifest.json").read_text(encoding="utf-8"))
+
+          value115 = manifest115["browser_specific_settings"]["gecko"].pop("strict_min_version")
+          value128 = manifest128["browser_specific_settings"]["gecko"].pop("strict_min_version")
+
+          if value115 != "115.0" or value128 != "128.0":
+              raise SystemExit(f"Unexpected minimum versions: {value115!r}, {value128!r}")
+          if manifest115 != manifest128:
+              raise SystemExit("The manifests differ by more than desktop strict_min_version")
+
+          print("Verified: every packaged byte is identical except desktop strict_min_version (115.0 vs 128.0).")
+          PY

--- a/.github/workflows/firefox-compatibility-audit.yml
+++ b/.github/workflows/firefox-compatibility-audit.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  SOURCE_COMMIT: 0dcc9c9859fb27d115894d979930ac959e516b72
+  SOURCE_COMMIT: c5fbdcd0d716f9e74a4283708d2a25ca403b6e47
 
 jobs:
   lint-release-package:
@@ -34,7 +34,7 @@ jobs:
             android: "128.0"
 
     steps:
-      - name: Check out exact UltimaDark 1.6.70 source
+      - name: Check out exact latest UltimaDark source
         uses: actions/checkout@v4
         with:
           ref: ${{ env.SOURCE_COMMIT }}
@@ -48,9 +48,9 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
-          grep -q '"version": "1.6.70"' manifest.json
+          grep -q '"version": "1.6.72"' manifest.json
 
-      - name: Build exact 1.6.70 release package
+      - name: Build exact latest release package
         shell: bash
         run: |
           set -euo pipefail
@@ -60,6 +60,7 @@ jobs:
           files=(
             manifest.json
             uDarkTools.htm
+            uDarkTools.js
             inject_css_override_no_edit.css
             inject_css_override_top_only.css
             inject_css_override.css

--- a/.github/workflows/firefox-compatibility-audit.yml
+++ b/.github/workflows/firefox-compatibility-audit.yml
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 jobs:
-  lint-compatibility:
-    name: web-ext lint (Firefox ${{ matrix.minimum }})
+  lint-release-package:
+    name: Mozilla lint — Firefox ${{ matrix.minimum }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -24,135 +24,135 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
 
-      - name: Prepare isolated extension tree
+      - name: Build exact release package
+        shell: bash
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/extension"
-          rsync -a --delete --exclude '.git/' --exclude '.github/' ./ "$RUNNER_TEMP/extension/"
-          python3 - "$RUNNER_TEMP/extension/manifest.json" "${{ matrix.minimum }}" <<'PY'
-          import pathlib, re, sys
+
+          package="$RUNNER_TEMP/extension"
+          mkdir -p "$package"
+
+          files=(
+            manifest.json
+            uDarkTools.htm
+            uDarkTools.js
+            inject_css_override_no_edit.css
+            inject_css_override_top_only.css
+            inject_css_override.css
+            inject_css_suggested.css
+            inject_css_suggested_no_edit.css
+            background.js
+            entities.json
+            uDarkEncoder.js
+            icons
+            Listeners.js
+            contentScriptClass.js
+            websitesOverrideScript.js
+            backgroundClass.js
+            fakeContentScriptClass.js
+            popup/popup.html
+            popup/bundle.js
+            popup/bundle.js.map
+            popup/bundle.css
+            popup/options_styles.css
+            popup/bootstrap-icons-CVBWLLHT.woff2
+            popup/bootstrap-icons-VQNJTM6Q.woff
+            popup/modules
+            popup/bootstrapdarkened.css
+            imageWorker/imageWorkerBundle-native.js
+            imageWorker/imageWorkerBundle-pooledAI.js
+            imageWorker/imageWorkerBundle-pooledBench.js
+            imageWorker/imageWorkerBundle-pooledHeuristic.js
+            imageWorker/imageClassifierModel.json
+            imageWorker/imageClassifierModel.weights.bin
+          )
+
+          for item in "${files[@]}"; do
+            mkdir -p "$package/$(dirname "$item")"
+            cp -a "$item" "$package/$item"
+          done
+
+          # The release workflow removes full-line // comments before packaging.
+          sed -i 's/^[[:space:]]*\/\/.*$//g' "$package/manifest.json"
+
+          python3 - "$package/manifest.json" "${{ matrix.minimum }}" <<'PY'
+          import json
+          import pathlib
+          import sys
+
           path = pathlib.Path(sys.argv[1])
-          text = path.read_text(encoding="utf-8")
-          pattern = r'("gecko"\s*:\s*\{.*?"strict_min_version"\s*:\s*")[^"]+("\s*,)'
-          patched, count = re.subn(pattern, rf'\g<1>{sys.argv[2]}\2', text, count=1, flags=re.S)
-          if count != 1:
-              raise SystemExit("Could not patch desktop gecko.strict_min_version")
-          path.write_text(patched, encoding="utf-8")
+          minimum = sys.argv[2]
+          manifest = json.loads(path.read_text(encoding="utf-8"))
+          manifest["browser_specific_settings"]["gecko"]["strict_min_version"] = minimum
+          path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
           PY
 
-      - name: Run Mozilla web-ext lint
-        continue-on-error: true
+          (cd "$package" && zip -qr "$RUNNER_TEMP/UltimaDark-firefox-${{ matrix.minimum }}.zip" .)
+
+      - name: Show Mozilla linter version
+        run: npx --yes web-ext@latest --version
+
+      - name: Run Mozilla Extension Linter
+        shell: bash
         run: |
+          set +e
           npx --yes web-ext@latest lint \
             --source-dir "$RUNNER_TEMP/extension" \
-            --output json > "web-ext-firefox-${{ matrix.minimum }}.json"
+            --output json \
+            > "$RUNNER_TEMP/firefox-${{ matrix.minimum }}-lint.json"
+          echo "lint_exit_code=$?" >> "$GITHUB_ENV"
+          exit 0
 
-      - name: Summarize lint result
+      - name: Produce report
+        shell: bash
         run: |
-          python3 - "web-ext-firefox-${{ matrix.minimum }}.json" "${{ matrix.minimum }}" <<'PY'
-          import json, os, pathlib, sys
+          python3 - "$RUNNER_TEMP/firefox-${{ matrix.minimum }}-lint.json" "${{ matrix.minimum }}" <<'PY'
+          import json
+          import os
+          import pathlib
+          import sys
+
           report = pathlib.Path(sys.argv[1])
+          minimum = sys.argv[2]
           data = json.loads(report.read_text(encoding="utf-8"))
           summary = data.get("summary", {})
+
           lines = [
-              f"## Firefox {sys.argv[2]} web-ext lint", "",
+              f"## Firefox {minimum}",
+              "",
               f"- Errors: **{summary.get('errors', 0)}**",
               f"- Warnings: **{summary.get('warnings', 0)}**",
-              f"- Notices: **{summary.get('notices', 0)}**", ""
+              f"- Notices: **{summary.get('notices', 0)}**",
+              f"- Linter exit code: **{os.environ.get('lint_exit_code', '?')}**",
+              "",
+              "### Messages",
+              "",
           ]
+
           messages = data.get("errors", []) + data.get("warnings", []) + data.get("notices", [])
-          if messages:
-              lines += ["### Messages", ""]
-              for item in messages:
-                  location = f" — `{item.get('file')}`" if item.get("file") else ""
-                  lines.append(f"- {item.get('message', 'Unknown message')}{location}")
-                  if item.get("description"):
-                      lines.append(f"  - {item['description']}")
+          for item in messages:
+              location = item.get("file") or "manifest/package"
+              lines.append(f"- **{item.get('message', 'Unknown message')}** — `{location}`")
+              description = item.get("description")
+              if description:
+                  lines.append(f"  - {description}")
+
           text = "\n".join(lines) + "\n"
-          report.with_suffix(".md").write_text(text, encoding="utf-8")
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as output:
-              output.write(text)
+          output = pathlib.Path(f"firefox-{minimum}-lint.md")
+          output.write_text(text, encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_file:
+              summary_file.write(text)
           PY
 
       - uses: actions/upload-artifact@v4
         with:
-          name: web-ext-firefox-${{ matrix.minimum }}
+          name: firefox-${{ matrix.minimum }}-mozilla-lint
           path: |
-            web-ext-firefox-${{ matrix.minimum }}.json
-            web-ext-firefox-${{ matrix.minimum }}.md
-
-  firefox-115-smoke-test:
-    name: Load extension in Firefox 115 ESR
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Install Firefox 115 runtime libraries
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libdbus-glib-1-2 libgtk-3-0 libasound2t64
-
-      - name: Prepare Firefox 115-compatible manifest
-        run: |
-          set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/extension"
-          rsync -a --delete --exclude '.git/' --exclude '.github/' ./ "$RUNNER_TEMP/extension/"
-          python3 - "$RUNNER_TEMP/extension/manifest.json" <<'PY'
-          import pathlib, re, sys
-          path = pathlib.Path(sys.argv[1])
-          text = path.read_text(encoding="utf-8")
-          pattern = r'("gecko"\s*:\s*\{.*?"strict_min_version"\s*:\s*")[^"]+("\s*,)'
-          patched, count = re.subn(pattern, r'\g<1>115.0\2', text, count=1, flags=re.S)
-          if count != 1:
-              raise SystemExit("Could not patch desktop gecko.strict_min_version")
-          path.write_text(patched, encoding="utf-8")
-          PY
-
-      - name: Download Firefox 115 ESR
-        run: |
-          set -euo pipefail
-          curl -fsSL \
-            "https://archive.mozilla.org/pub/firefox/releases/115.18.0esr/linux-x86_64/en-US/firefox-115.18.0esr.tar.bz2" \
-            -o "$RUNNER_TEMP/firefox.tar.bz2"
-          tar -xjf "$RUNNER_TEMP/firefox.tar.bz2" -C "$RUNNER_TEMP"
-          "$RUNNER_TEMP/firefox/firefox" --version
-
-      - name: Smoke-test extension startup
-        run: |
-          set -euo pipefail
-          LOG="$RUNNER_TEMP/firefox-115-web-ext.log"
-          set +e
-          timeout 30s xvfb-run -a npx --yes web-ext@latest run \
-            --source-dir "$RUNNER_TEMP/extension" \
-            --firefox "$RUNNER_TEMP/firefox/firefox" \
-            --no-reload --start-url about:blank >"$LOG" 2>&1
-          status=$?
-          set -e
-          cat "$LOG"
-          if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then exit "$status"; fi
-          if grep -Eqi "(ExtensionError|Failed to install|not compatible|minimum Firefox version)" "$LOG"; then exit 1; fi
-          if ! grep -Eqi "(Installed|Running web extension|Launching extension)" "$LOG"; then
-            echo "Could not confirm that Firefox 115 loaded the extension" >&2
-            exit 1
-          fi
-          {
-            echo "## Firefox 115 ESR runtime smoke test"
-            echo
-            echo "Firefox 115.18.0 ESR accepted and launched the extension with only desktop strict_min_version changed to 115.0."
-            echo
-            echo "This proves package loading and startup, not exhaustive website-level behavior."
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: firefox-115-smoke-test
-          path: ${{ runner.temp }}/firefox-115-web-ext.log
+            ${{ runner.temp }}/UltimaDark-firefox-${{ matrix.minimum }}.zip
+            ${{ runner.temp }}/firefox-${{ matrix.minimum }}-lint.json
+            firefox-${{ matrix.minimum }}-lint.md

--- a/.github/workflows/firefox-compatibility-audit.yml
+++ b/.github/workflows/firefox-compatibility-audit.yml
@@ -2,15 +2,6 @@ name: Firefox compatibility audit
 
 on:
   workflow_dispatch:
-    inputs:
-      firefox_min_version:
-        description: Desktop Firefox minimum version to audit
-        required: true
-        default: "115.0"
-      firefox_runtime_version:
-        description: Firefox ESR runtime version used for the smoke test
-        required: true
-        default: "115.18.0esr"
   pull_request:
     paths:
       - "manifest.json"
@@ -29,100 +20,64 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        minimum:
-          - "115.0"
-          - "128.0"
+        minimum: ["115.0", "128.0"]
 
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
 
       - name: Prepare isolated extension tree
-        shell: bash
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/extension"
-          rsync -a --delete \
-            --exclude '.git/' \
-            --exclude '.github/' \
-            ./ "$RUNNER_TEMP/extension/"
-
+          rsync -a --delete --exclude '.git/' --exclude '.github/' ./ "$RUNNER_TEMP/extension/"
           python3 - "$RUNNER_TEMP/extension/manifest.json" "${{ matrix.minimum }}" <<'PY'
-          import pathlib
-          import re
-          import sys
-
+          import pathlib, re, sys
           path = pathlib.Path(sys.argv[1])
-          minimum = sys.argv[2]
           text = path.read_text(encoding="utf-8")
           pattern = r'("gecko"\s*:\s*\{.*?"strict_min_version"\s*:\s*")[^"]+("\s*,)'
-          patched, count = re.subn(pattern, rf'\g<1>{minimum}\2', text, count=1, flags=re.S)
+          patched, count = re.subn(pattern, rf'\g<1>{sys.argv[2]}\2', text, count=1, flags=re.S)
           if count != 1:
               raise SystemExit("Could not patch desktop gecko.strict_min_version")
           path.write_text(patched, encoding="utf-8")
           PY
 
       - name: Run Mozilla web-ext lint
-        shell: bash
         run: |
-          set -o pipefail
           npx --yes web-ext@latest lint \
             --source-dir "$RUNNER_TEMP/extension" \
-            --output json \
-            > "web-ext-firefox-${{ matrix.minimum }}.json"
+            --output json > "web-ext-firefox-${{ matrix.minimum }}.json"
 
       - name: Summarize lint result
-        shell: bash
         run: |
           python3 - "web-ext-firefox-${{ matrix.minimum }}.json" "${{ matrix.minimum }}" <<'PY'
-          import json
-          import pathlib
-          import sys
-
-          report_path = pathlib.Path(sys.argv[1])
-          minimum = sys.argv[2]
-          data = json.loads(report_path.read_text(encoding="utf-8"))
+          import json, os, pathlib, sys
+          report = pathlib.Path(sys.argv[1])
+          data = json.loads(report.read_text(encoding="utf-8"))
           summary = data.get("summary", {})
-          errors = summary.get("errors", 0)
-          warnings = summary.get("warnings", 0)
-          notices = summary.get("notices", 0)
-
           lines = [
-              f"## Firefox {minimum} web-ext lint",
-              "",
-              f"- Errors: **{errors}**",
-              f"- Warnings: **{warnings}**",
-              f"- Notices: **{notices}**",
-              "",
+              f"## Firefox {sys.argv[2]} web-ext lint", "",
+              f"- Errors: **{summary.get('errors', 0)}**",
+              f"- Warnings: **{summary.get('warnings', 0)}**",
+              f"- Notices: **{summary.get('notices', 0)}**", ""
           ]
-
           messages = data.get("errors", []) + data.get("warnings", []) + data.get("notices", [])
           if messages:
               lines += ["### Messages", ""]
               for item in messages:
-                  message = item.get("message", "Unknown message")
-                  file_name = item.get("file", "")
-                  description = item.get("description", "")
-                  location = f" — `{file_name}`" if file_name else ""
-                  lines.append(f"- {message}{location}")
-                  if description:
-                      lines.append(f"  - {description}")
-
-          with open(pathlib.Path.home() / "summary.md", "w", encoding="utf-8") as output:
-              output.write("\n".join(lines) + "\n")
-          with open(pathlib.Path(sys.argv[1]).with_suffix(".md"), "w", encoding="utf-8") as output:
-              output.write("\n".join(lines) + "\n")
-          with open(__import__('os').environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as output:
-              output.write("\n".join(lines) + "\n")
+                  location = f" — `{item.get('file')}`" if item.get("file") else ""
+                  lines.append(f"- {item.get('message', 'Unknown message')}{location}")
+                  if item.get("description"):
+                      lines.append(f"  - {item['description']}")
+          text = "\n".join(lines) + "\n"
+          report.with_suffix(".md").write_text(text, encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as output:
+              output.write(text)
           PY
 
-      - name: Upload lint report
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: web-ext-firefox-${{ matrix.minimum }}
           path: |
@@ -134,29 +89,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
 
+      - name: Install Firefox 115 runtime libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-glib-1-2 libgtk-3-0 libasound2t64
+
       - name: Prepare Firefox 115-compatible manifest
-        shell: bash
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/extension"
-          rsync -a --delete \
-            --exclude '.git/' \
-            --exclude '.github/' \
-            ./ "$RUNNER_TEMP/extension/"
-
+          rsync -a --delete --exclude '.git/' --exclude '.github/' ./ "$RUNNER_TEMP/extension/"
           python3 - "$RUNNER_TEMP/extension/manifest.json" <<'PY'
-          import pathlib
-          import re
-          import sys
-
+          import pathlib, re, sys
           path = pathlib.Path(sys.argv[1])
           text = path.read_text(encoding="utf-8")
           pattern = r'("gecko"\s*:\s*\{.*?"strict_min_version"\s*:\s*")[^"]+("\s*,)'
@@ -167,7 +116,6 @@ jobs:
           PY
 
       - name: Download Firefox 115 ESR
-        shell: bash
         run: |
           set -euo pipefail
           curl -fsSL \
@@ -177,7 +125,6 @@ jobs:
           "$RUNNER_TEMP/firefox/firefox" --version
 
       - name: Smoke-test extension startup
-        shell: bash
         run: |
           set -euo pipefail
           LOG="$RUNNER_TEMP/firefox-115-web-ext.log"
@@ -185,39 +132,25 @@ jobs:
           timeout 30s xvfb-run -a npx --yes web-ext@latest run \
             --source-dir "$RUNNER_TEMP/extension" \
             --firefox "$RUNNER_TEMP/firefox/firefox" \
-            --no-reload \
-            --start-url about:blank \
-            >"$LOG" 2>&1
+            --no-reload --start-url about:blank >"$LOG" 2>&1
           status=$?
           set -e
-
           cat "$LOG"
-
-          if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
-            echo "web-ext exited unexpectedly with status $status" >&2
-            exit "$status"
-          fi
-
-          if grep -Eqi "(ExtensionError|Error:.*extension|Failed to install|not compatible|minimum Firefox version)" "$LOG"; then
-            echo "Firefox 115 reported an extension loading error" >&2
-            exit 1
-          fi
-
-          if ! grep -Eqi "(Installed|Running web extension|The extension will reload|Launching extension)" "$LOG"; then
+          if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then exit "$status"; fi
+          if grep -Eqi "(ExtensionError|Failed to install|not compatible|minimum Firefox version)" "$LOG"; then exit 1; fi
+          if ! grep -Eqi "(Installed|Running web extension|Launching extension)" "$LOG"; then
             echo "Could not confirm that Firefox 115 loaded the extension" >&2
             exit 1
           fi
-
           {
             echo "## Firefox 115 ESR runtime smoke test"
             echo
-            echo "The extension was accepted and launched by Firefox 115.18.0 ESR with only desktop strict_min_version changed to 115.0."
+            echo "Firefox 115.18.0 ESR accepted and launched the extension with only desktop strict_min_version changed to 115.0."
             echo
-            echo "This proves package loading and background startup, not exhaustive website-level behavior."
+            echo "This proves package loading and startup, not exhaustive website-level behavior."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload Firefox startup log
-        if: always()
+      - if: always()
         uses: actions/upload-artifact@v4
         with:
           name: firefox-115-smoke-test

--- a/.github/workflows/firefox-compatibility-audit.yml
+++ b/.github/workflows/firefox-compatibility-audit.yml
@@ -60,7 +60,6 @@ jobs:
           files=(
             manifest.json
             uDarkTools.htm
-            uDarkTools.js
             inject_css_override_no_edit.css
             inject_css_override_top_only.css
             inject_css_override.css

--- a/.github/workflows/firefox-compatibility-audit.yml
+++ b/.github/workflows/firefox-compatibility-audit.yml
@@ -1,0 +1,224 @@
+name: Firefox compatibility audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      firefox_min_version:
+        description: Desktop Firefox minimum version to audit
+        required: true
+        default: "115.0"
+      firefox_runtime_version:
+        description: Firefox ESR runtime version used for the smoke test
+        required: true
+        default: "115.18.0esr"
+  pull_request:
+    paths:
+      - "manifest.json"
+      - "**/*.js"
+      - "**/*.html"
+      - "**/*.css"
+      - ".github/workflows/firefox-compatibility-audit.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint-compatibility:
+    name: web-ext lint (Firefox ${{ matrix.minimum }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        minimum:
+          - "115.0"
+          - "128.0"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Prepare isolated extension tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/extension"
+          rsync -a --delete \
+            --exclude '.git/' \
+            --exclude '.github/' \
+            ./ "$RUNNER_TEMP/extension/"
+
+          python3 - "$RUNNER_TEMP/extension/manifest.json" "${{ matrix.minimum }}" <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          path = pathlib.Path(sys.argv[1])
+          minimum = sys.argv[2]
+          text = path.read_text(encoding="utf-8")
+          pattern = r'("gecko"\s*:\s*\{.*?"strict_min_version"\s*:\s*")[^"]+("\s*,)'
+          patched, count = re.subn(pattern, rf'\g<1>{minimum}\2', text, count=1, flags=re.S)
+          if count != 1:
+              raise SystemExit("Could not patch desktop gecko.strict_min_version")
+          path.write_text(patched, encoding="utf-8")
+          PY
+
+      - name: Run Mozilla web-ext lint
+        shell: bash
+        run: |
+          set -o pipefail
+          npx --yes web-ext@latest lint \
+            --source-dir "$RUNNER_TEMP/extension" \
+            --output json \
+            > "web-ext-firefox-${{ matrix.minimum }}.json"
+
+      - name: Summarize lint result
+        shell: bash
+        run: |
+          python3 - "web-ext-firefox-${{ matrix.minimum }}.json" "${{ matrix.minimum }}" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          report_path = pathlib.Path(sys.argv[1])
+          minimum = sys.argv[2]
+          data = json.loads(report_path.read_text(encoding="utf-8"))
+          summary = data.get("summary", {})
+          errors = summary.get("errors", 0)
+          warnings = summary.get("warnings", 0)
+          notices = summary.get("notices", 0)
+
+          lines = [
+              f"## Firefox {minimum} web-ext lint",
+              "",
+              f"- Errors: **{errors}**",
+              f"- Warnings: **{warnings}**",
+              f"- Notices: **{notices}**",
+              "",
+          ]
+
+          messages = data.get("errors", []) + data.get("warnings", []) + data.get("notices", [])
+          if messages:
+              lines += ["### Messages", ""]
+              for item in messages:
+                  message = item.get("message", "Unknown message")
+                  file_name = item.get("file", "")
+                  description = item.get("description", "")
+                  location = f" — `{file_name}`" if file_name else ""
+                  lines.append(f"- {message}{location}")
+                  if description:
+                      lines.append(f"  - {description}")
+
+          with open(pathlib.Path.home() / "summary.md", "w", encoding="utf-8") as output:
+              output.write("\n".join(lines) + "\n")
+          with open(pathlib.Path(sys.argv[1]).with_suffix(".md"), "w", encoding="utf-8") as output:
+              output.write("\n".join(lines) + "\n")
+          with open(__import__('os').environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as output:
+              output.write("\n".join(lines) + "\n")
+          PY
+
+      - name: Upload lint report
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-ext-firefox-${{ matrix.minimum }}
+          path: |
+            web-ext-firefox-${{ matrix.minimum }}.json
+            web-ext-firefox-${{ matrix.minimum }}.md
+
+  firefox-115-smoke-test:
+    name: Load extension in Firefox 115 ESR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Prepare Firefox 115-compatible manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/extension"
+          rsync -a --delete \
+            --exclude '.git/' \
+            --exclude '.github/' \
+            ./ "$RUNNER_TEMP/extension/"
+
+          python3 - "$RUNNER_TEMP/extension/manifest.json" <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          path = pathlib.Path(sys.argv[1])
+          text = path.read_text(encoding="utf-8")
+          pattern = r'("gecko"\s*:\s*\{.*?"strict_min_version"\s*:\s*")[^"]+("\s*,)'
+          patched, count = re.subn(pattern, r'\g<1>115.0\2', text, count=1, flags=re.S)
+          if count != 1:
+              raise SystemExit("Could not patch desktop gecko.strict_min_version")
+          path.write_text(patched, encoding="utf-8")
+          PY
+
+      - name: Download Firefox 115 ESR
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL \
+            "https://archive.mozilla.org/pub/firefox/releases/115.18.0esr/linux-x86_64/en-US/firefox-115.18.0esr.tar.bz2" \
+            -o "$RUNNER_TEMP/firefox.tar.bz2"
+          tar -xjf "$RUNNER_TEMP/firefox.tar.bz2" -C "$RUNNER_TEMP"
+          "$RUNNER_TEMP/firefox/firefox" --version
+
+      - name: Smoke-test extension startup
+        shell: bash
+        run: |
+          set -euo pipefail
+          LOG="$RUNNER_TEMP/firefox-115-web-ext.log"
+          set +e
+          timeout 30s xvfb-run -a npx --yes web-ext@latest run \
+            --source-dir "$RUNNER_TEMP/extension" \
+            --firefox "$RUNNER_TEMP/firefox/firefox" \
+            --no-reload \
+            --start-url about:blank \
+            >"$LOG" 2>&1
+          status=$?
+          set -e
+
+          cat "$LOG"
+
+          if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
+            echo "web-ext exited unexpectedly with status $status" >&2
+            exit "$status"
+          fi
+
+          if grep -Eqi "(ExtensionError|Error:.*extension|Failed to install|not compatible|minimum Firefox version)" "$LOG"; then
+            echo "Firefox 115 reported an extension loading error" >&2
+            exit 1
+          fi
+
+          if ! grep -Eqi "(Installed|Running web extension|The extension will reload|Launching extension)" "$LOG"; then
+            echo "Could not confirm that Firefox 115 loaded the extension" >&2
+            exit 1
+          fi
+
+          {
+            echo "## Firefox 115 ESR runtime smoke test"
+            echo
+            echo "The extension was accepted and launched by Firefox 115.18.0 ESR with only desktop strict_min_version changed to 115.0."
+            echo
+            echo "This proves package loading and background startup, not exhaustive website-level behavior."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Firefox startup log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: firefox-115-smoke-test
+          path: ${{ runner.temp }}/firefox-115-web-ext.log

--- a/.github/workflows/firefox-compatibility-audit.yml
+++ b/.github/workflows/firefox-compatibility-audit.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        minimum: ["115.0", "128.0"]
+        minimum: ["79.0", "115.0", "128.0"]
 
     steps:
       - uses: actions/checkout@v4
@@ -78,13 +78,11 @@ jobs:
             cp -a "$item" "$package/$item"
           done
 
-          # Reproduce the manifest transformations from the release workflow.
           sed -i 's/^[[:space:]]*\/\/.*$//g' "$package/manifest.json"
           sed -i \
             's/{0a0f6dea-3957-4bb9-9eec-2ef2b9e5bcec}/{7c7f6dea-3957-4bb9-9eec-2ef2b9e5bcec}/g' \
             "$package/manifest.json"
 
-          # Change only the desktop minimum under browser_specific_settings.gecko.
           python3 - "$package/manifest.json" "${{ matrix.minimum }}" <<'PY'
           import json
           import pathlib
@@ -162,8 +160,8 @@ jobs:
             ${{ runner.temp }}/firefox-${{ matrix.minimum }}-lint.json
             firefox-${{ matrix.minimum }}-lint.md
 
-  verify-package-delta:
-    name: Verify 115/128 package delta
+  verify-controls:
+    name: Verify package deltas and positive control
     needs: lint-release-package
     runs-on: ubuntu-latest
 
@@ -173,11 +171,12 @@ jobs:
           pattern: firefox-*-mozilla-lint
           path: artifacts
 
-      - name: Prove packages differ only by desktop minimum
+      - name: Prove packages differ only by desktop minimum and 79 triggers more findings
         shell: bash
         run: |
           set -euo pipefail
-          mkdir pkg115 pkg128
+          mkdir pkg79 pkg115 pkg128
+          unzip -q artifacts/firefox-79.0-mozilla-lint/_temp/UltimaDark-firefox-79.0.zip -d pkg79
           unzip -q artifacts/firefox-115.0-mozilla-lint/_temp/UltimaDark-firefox-115.0.zip -d pkg115
           unzip -q artifacts/firefox-128.0-mozilla-lint/_temp/UltimaDark-firefox-128.0.zip -d pkg128
 
@@ -185,30 +184,47 @@ jobs:
           import json
           import pathlib
 
-          left = pathlib.Path("pkg115")
-          right = pathlib.Path("pkg128")
+          packages = {
+              "79.0": pathlib.Path("pkg79"),
+              "115.0": pathlib.Path("pkg115"),
+              "128.0": pathlib.Path("pkg128"),
+          }
 
-          left_files = sorted(p.relative_to(left) for p in left.rglob("*") if p.is_file())
-          right_files = sorted(p.relative_to(right) for p in right.rglob("*") if p.is_file())
-          if left_files != right_files:
-              raise SystemExit("The Firefox 115 and 128 packages do not contain the same files")
+          baseline_files = sorted(p.relative_to(packages["128.0"]) for p in packages["128.0"].rglob("*") if p.is_file())
+          manifests = {}
 
-          for relative in left_files:
-              if relative.as_posix() == "manifest.json":
-                  continue
-              if (left / relative).read_bytes() != (right / relative).read_bytes():
-                  raise SystemExit(f"Unexpected package difference: {relative}")
+          for version, root in packages.items():
+              files = sorted(p.relative_to(root) for p in root.rglob("*") if p.is_file())
+              if files != baseline_files:
+                  raise SystemExit(f"Firefox {version} package file list differs")
+              for relative in files:
+                  if relative.as_posix() == "manifest.json":
+                      continue
+                  if (root / relative).read_bytes() != (packages["128.0"] / relative).read_bytes():
+                      raise SystemExit(f"Unexpected package difference for Firefox {version}: {relative}")
+              manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+              value = manifest["browser_specific_settings"]["gecko"].pop("strict_min_version")
+              if value != version:
+                  raise SystemExit(f"Unexpected minimum for Firefox {version}: {value}")
+              manifests[version] = manifest
 
-          manifest115 = json.loads((left / "manifest.json").read_text(encoding="utf-8"))
-          manifest128 = json.loads((right / "manifest.json").read_text(encoding="utf-8"))
-
-          value115 = manifest115["browser_specific_settings"]["gecko"].pop("strict_min_version")
-          value128 = manifest128["browser_specific_settings"]["gecko"].pop("strict_min_version")
-
-          if value115 != "115.0" or value128 != "128.0":
-              raise SystemExit(f"Unexpected minimum versions: {value115!r}, {value128!r}")
-          if manifest115 != manifest128:
+          if not (manifests["79.0"] == manifests["115.0"] == manifests["128.0"]):
               raise SystemExit("The manifests differ by more than desktop strict_min_version")
 
-          print("Verified: every packaged byte is identical except desktop strict_min_version (115.0 vs 128.0).")
+          def load_summary(version):
+              report = pathlib.Path(f"artifacts/firefox-{version}-mozilla-lint/_temp/firefox-{version}-lint.json")
+              return json.loads(report.read_text(encoding="utf-8")).get("summary", {})
+
+          s79 = load_summary("79.0")
+          s115 = load_summary("115.0")
+          s128 = load_summary("128.0")
+
+          total79 = s79.get("errors", 0) + s79.get("warnings", 0) + s79.get("notices", 0)
+          total115 = s115.get("errors", 0) + s115.get("warnings", 0) + s115.get("notices", 0)
+          total128 = s128.get("errors", 0) + s128.get("warnings", 0) + s128.get("notices", 0)
+
+          if total79 <= total115 or total79 <= total128:
+              raise SystemExit(f"Positive control failed: Firefox 79 did not produce more findings ({total79} vs {total115}/{total128})")
+
+          print(f"Positive control passed: Firefox 79 produced {total79} findings vs {total115} for 115 and {total128} for 128.")
           PY

--- a/.github/workflows/firefox-compatibility-audit.yml
+++ b/.github/workflows/firefox-compatibility-audit.yml
@@ -4,36 +4,56 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - "manifest.json"
-      - "**/*.js"
-      - "**/*.html"
-      - "**/*.css"
       - ".github/workflows/firefox-compatibility-audit.yml"
 
 permissions:
   contents: read
 
+env:
+  SOURCE_COMMIT: 0dcc9c9859fb27d115894d979930ac959e516b72
+
 jobs:
   lint-release-package:
-    name: Mozilla lint — Firefox ${{ matrix.minimum }}
+    name: Mozilla lint — ${{ matrix.name }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        minimum: ["79.0", "115.0", "128.0"]
+        include:
+          - name: Firefox 79 / Android 42
+            key: legacy-79-42
+            desktop: "79.0"
+            android: "42.0"
+          - name: Firefox 115 / Android 128
+            key: desktop-115
+            desktop: "115.0"
+            android: "128.0"
+          - name: Firefox 128 / Android 128
+            key: desktop-128
+            desktop: "128.0"
+            android: "128.0"
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out exact UltimaDark 1.6.70 source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SOURCE_COMMIT }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
 
-      - name: Build exact release package
+      - name: Assert source identity
         shell: bash
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
+          grep -q '"version": "1.6.70"' manifest.json
 
+      - name: Build exact 1.6.70 release package
+        shell: bash
+        run: |
+          set -euo pipefail
           package="$RUNNER_TEMP/extension"
           mkdir -p "$package"
 
@@ -79,26 +99,18 @@ jobs:
           done
 
           sed -i 's/^[[:space:]]*\/\/.*$//g' "$package/manifest.json"
-          sed -i \
-            's/{0a0f6dea-3957-4bb9-9eec-2ef2b9e5bcec}/{7c7f6dea-3957-4bb9-9eec-2ef2b9e5bcec}/g' \
-            "$package/manifest.json"
+          sed -i 's/{0a0f6dea-3957-4bb9-9eec-2ef2b9e5bcec}/{7c7f6dea-3957-4bb9-9eec-2ef2b9e5bcec}/g' "$package/manifest.json"
 
-          python3 - "$package/manifest.json" "${{ matrix.minimum }}" <<'PY'
-          import json
-          import pathlib
-          import sys
-
+          python3 - "$package/manifest.json" "${{ matrix.desktop }}" "${{ matrix.android }}" <<'PY'
+          import json, pathlib, sys
           path = pathlib.Path(sys.argv[1])
-          minimum = sys.argv[2]
           manifest = json.loads(path.read_text(encoding="utf-8"))
-          manifest["browser_specific_settings"]["gecko"]["strict_min_version"] = minimum
+          manifest["browser_specific_settings"]["gecko"]["strict_min_version"] = sys.argv[2]
+          manifest["browser_specific_settings"]["gecko_android"]["strict_min_version"] = sys.argv[3]
           path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
           PY
 
-          (cd "$package" && zip -qr "$RUNNER_TEMP/UltimaDark-firefox-${{ matrix.minimum }}.zip" .)
-
-      - name: Show Mozilla linter version
-        run: npx --yes web-ext@latest --version
+          (cd "$package" && zip -qr "$RUNNER_TEMP/UltimaDark-${{ matrix.key }}.zip" .)
 
       - name: Run Mozilla Extension Linter
         shell: bash
@@ -107,124 +119,80 @@ jobs:
           npx --yes web-ext@latest lint \
             --source-dir "$RUNNER_TEMP/extension" \
             --output json \
-            > "$RUNNER_TEMP/firefox-${{ matrix.minimum }}-lint.json"
+            > "$RUNNER_TEMP/${{ matrix.key }}-lint.json"
           echo "lint_exit_code=$?" >> "$GITHUB_ENV"
           exit 0
 
       - name: Produce report
         shell: bash
         run: |
-          python3 - "$RUNNER_TEMP/firefox-${{ matrix.minimum }}-lint.json" "${{ matrix.minimum }}" <<'PY'
-          import json
-          import os
-          import pathlib
-          import sys
-
-          report = pathlib.Path(sys.argv[1])
-          minimum = sys.argv[2]
-          data = json.loads(report.read_text(encoding="utf-8"))
+          python3 - "$RUNNER_TEMP/${{ matrix.key }}-lint.json" "${{ matrix.name }}" <<'PY'
+          import json, os, pathlib, sys
+          data = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
           summary = data.get("summary", {})
-
           lines = [
-              f"## Firefox {minimum}",
-              "",
+              f"## {sys.argv[2]}", "",
               f"- Errors: **{summary.get('errors', 0)}**",
               f"- Warnings: **{summary.get('warnings', 0)}**",
               f"- Notices: **{summary.get('notices', 0)}**",
-              f"- Linter exit code: **{os.environ.get('lint_exit_code', '?')}**",
-              "",
-              "### Messages",
-              "",
+              f"- Linter exit code: **{os.environ.get('lint_exit_code', '?')}**", "",
           ]
-
-          messages = data.get("errors", []) + data.get("warnings", []) + data.get("notices", [])
-          for item in messages:
-              location = item.get("file") or "manifest/package"
-              lines.append(f"- **{item.get('message', 'Unknown message')}** — `{location}`")
-              description = item.get("description")
-              if description:
-                  lines.append(f"  - {description}")
-
+          for item in data.get("errors", []) + data.get("warnings", []) + data.get("notices", []):
+              lines.append(f"- {item.get('message', 'Unknown')} — `{item.get('file') or 'manifest/package'}`")
           text = "\n".join(lines) + "\n"
-          output = pathlib.Path(f"firefox-{minimum}-lint.md")
-          output.write_text(text, encoding="utf-8")
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_file:
-              summary_file.write(text)
+          pathlib.Path("${{ matrix.key }}-lint.md").write_text(text, encoding="utf-8")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as f:
+              f.write(text)
           PY
 
       - uses: actions/upload-artifact@v4
         with:
-          name: firefox-${{ matrix.minimum }}-mozilla-lint
+          name: ${{ matrix.key }}-mozilla-lint
           path: |
-            ${{ runner.temp }}/UltimaDark-firefox-${{ matrix.minimum }}.zip
-            ${{ runner.temp }}/firefox-${{ matrix.minimum }}-lint.json
-            firefox-${{ matrix.minimum }}-lint.md
+            ${{ runner.temp }}/UltimaDark-${{ matrix.key }}.zip
+            ${{ runner.temp }}/${{ matrix.key }}-lint.json
+            ${{ matrix.key }}-lint.md
 
-  verify-controls:
-    name: Verify package deltas and positive control
+  verify:
+    name: Verify exact source and package deltas
     needs: lint-release-package
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/download-artifact@v4
         with:
-          pattern: firefox-*-mozilla-lint
+          pattern: "*-mozilla-lint"
           path: artifacts
 
-      - name: Prove packages differ only by desktop minimum and 79 triggers more findings
+      - name: Verify packages and print comparison
         shell: bash
         run: |
           set -euo pipefail
-          mkdir pkg79 pkg115 pkg128
-          unzip -q artifacts/firefox-79.0-mozilla-lint/_temp/UltimaDark-firefox-79.0.zip -d pkg79
-          unzip -q artifacts/firefox-115.0-mozilla-lint/_temp/UltimaDark-firefox-115.0.zip -d pkg115
-          unzip -q artifacts/firefox-128.0-mozilla-lint/_temp/UltimaDark-firefox-128.0.zip -d pkg128
+          mkdir legacy target baseline
+          unzip -q artifacts/legacy-79-42-mozilla-lint/_temp/UltimaDark-legacy-79-42.zip -d legacy
+          unzip -q artifacts/desktop-115-mozilla-lint/_temp/UltimaDark-desktop-115.zip -d target
+          unzip -q artifacts/desktop-128-mozilla-lint/_temp/UltimaDark-desktop-128.zip -d baseline
 
           python3 <<'PY'
-          import json
-          import pathlib
-
-          packages = {
-              "79.0": pathlib.Path("pkg79"),
-              "115.0": pathlib.Path("pkg115"),
-              "128.0": pathlib.Path("pkg128"),
-          }
-
-          baseline_files = sorted(p.relative_to(packages["128.0"]) for p in packages["128.0"].rglob("*") if p.is_file())
+          import json, pathlib
+          roots = {"legacy": pathlib.Path("legacy"), "115": pathlib.Path("target"), "128": pathlib.Path("baseline")}
+          files = sorted(p.relative_to(roots["128"]) for p in roots["128"].rglob("*") if p.is_file())
           manifests = {}
+          for name, root in roots.items():
+              current = sorted(p.relative_to(root) for p in root.rglob("*") if p.is_file())
+              assert current == files, f"file list differs for {name}"
+              for rel in files:
+                  if rel.as_posix() != "manifest.json":
+                      assert (root/rel).read_bytes() == (roots["128"]/rel).read_bytes(), f"unexpected difference: {name}/{rel}"
+              m = json.loads((root/"manifest.json").read_text())
+              m["browser_specific_settings"]["gecko"].pop("strict_min_version")
+              m["browser_specific_settings"]["gecko_android"].pop("strict_min_version")
+              manifests[name] = m
+          assert manifests["legacy"] == manifests["115"] == manifests["128"], "manifests differ beyond minimum versions"
 
-          for version, root in packages.items():
-              files = sorted(p.relative_to(root) for p in root.rglob("*") if p.is_file())
-              if files != baseline_files:
-                  raise SystemExit(f"Firefox {version} package file list differs")
-              for relative in files:
-                  if relative.as_posix() == "manifest.json":
-                      continue
-                  if (root / relative).read_bytes() != (packages["128.0"] / relative).read_bytes():
-                      raise SystemExit(f"Unexpected package difference for Firefox {version}: {relative}")
-              manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
-              value = manifest["browser_specific_settings"]["gecko"].pop("strict_min_version")
-              if value != version:
-                  raise SystemExit(f"Unexpected minimum for Firefox {version}: {value}")
-              manifests[version] = manifest
-
-          if not (manifests["79.0"] == manifests["115.0"] == manifests["128.0"]):
-              raise SystemExit("The manifests differ by more than desktop strict_min_version")
-
-          def load_summary(version):
-              report = pathlib.Path(f"artifacts/firefox-{version}-mozilla-lint/_temp/firefox-{version}-lint.json")
-              return json.loads(report.read_text(encoding="utf-8")).get("summary", {})
-
-          s79 = load_summary("79.0")
-          s115 = load_summary("115.0")
-          s128 = load_summary("128.0")
-
-          total79 = s79.get("errors", 0) + s79.get("warnings", 0) + s79.get("notices", 0)
-          total115 = s115.get("errors", 0) + s115.get("warnings", 0) + s115.get("notices", 0)
-          total128 = s128.get("errors", 0) + s128.get("warnings", 0) + s128.get("notices", 0)
-
-          if total79 <= total115 or total79 <= total128:
-              raise SystemExit(f"Positive control failed: Firefox 79 did not produce more findings ({total79} vs {total115}/{total128})")
-
-          print(f"Positive control passed: Firefox 79 produced {total79} findings vs {total115} for 115 and {total128} for 128.")
+          def summary(key):
+              p = pathlib.Path(f"artifacts/{key}-mozilla-lint/_temp/{key}-lint.json")
+              return json.loads(p.read_text()).get("summary", {})
+          for key in ("legacy-79-42", "desktop-115", "desktop-128"):
+              s = summary(key)
+              print(f"{key}: {s.get('errors',0)} errors, {s.get('warnings',0)} warnings, {s.get('notices',0)} notices")
           PY

--- a/.github/workflows/firefox-compatibility-audit.yml
+++ b/.github/workflows/firefox-compatibility-audit.yml
@@ -2,15 +2,45 @@ name: Firefox compatibility audit
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - ".github/workflows/firefox-compatibility-audit.yml"
+    inputs:
+      source_ref:
+        description: Branch, tag, or commit to audit
+        required: true
+        default: master
+        type: string
+      legacy_desktop:
+        description: Legacy desktop Firefox minimum
+        required: true
+        default: "79.0"
+        type: string
+      legacy_android:
+        description: Legacy Firefox for Android minimum
+        required: true
+        default: "42.0"
+        type: string
+      target_desktop:
+        description: Target desktop Firefox minimum
+        required: true
+        default: "115.0"
+        type: string
+      target_android:
+        description: Target Firefox for Android minimum
+        required: true
+        default: "115.0"
+        type: string
+      baseline_desktop:
+        description: Baseline desktop Firefox minimum
+        required: true
+        default: "128.0"
+        type: string
+      baseline_android:
+        description: Baseline Firefox for Android minimum
+        required: true
+        default: "128.0"
+        type: string
 
 permissions:
   contents: read
-
-env:
-  SOURCE_COMMIT: c5fbdcd0d716f9e74a4283708d2a25ca403b6e47
 
 jobs:
   lint-release-package:
@@ -20,38 +50,50 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Firefox 79 / Android 42
-            key: legacy-79-42
-            desktop: "79.0"
-            android: "42.0"
-          - name: Firefox 115 / Android 128
-            key: desktop-115
-            desktop: "115.0"
-            android: "128.0"
-          - name: Firefox 128 / Android 128
-            key: desktop-128
-            desktop: "128.0"
-            android: "128.0"
+          - name: Firefox ${{ inputs.legacy_desktop }} / Android ${{ inputs.legacy_android }}
+            key: legacy
+            desktop: ${{ inputs.legacy_desktop }}
+            android: ${{ inputs.legacy_android }}
+          - name: Firefox ${{ inputs.target_desktop }} / Android ${{ inputs.target_android }}
+            key: target
+            desktop: ${{ inputs.target_desktop }}
+            android: ${{ inputs.target_android }}
+          - name: Firefox ${{ inputs.baseline_desktop }} / Android ${{ inputs.baseline_android }}
+            key: baseline
+            desktop: ${{ inputs.baseline_desktop }}
+            android: ${{ inputs.baseline_android }}
 
     steps:
-      - name: Check out exact latest UltimaDark source
+      - name: Check out selected UltimaDark source
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.SOURCE_COMMIT }}
+          ref: ${{ inputs.source_ref }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
 
-      - name: Assert source identity
+      - name: Report audited source
         shell: bash
+        env:
+          REQUESTED_SOURCE_REF: ${{ inputs.source_ref }}
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$SOURCE_COMMIT"
-          grep -q '"version": "1.6.72"' manifest.json
+          test -z "$(git status --porcelain)"
+          version=$(sed 's/^[[:space:]]*\/\/.*$//g' manifest.json | jq -r .version)
+          {
+            echo "## Audited source"
+            echo
+            echo "- Requested ref: \`$REQUESTED_SOURCE_REF\`"
+            echo "- Resolved commit: \`$(git rev-parse HEAD)\`"
+            echo "- UltimaDark version: \`$version\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build exact latest release package
         shell: bash
+        env:
+          DESKTOP_MIN_VERSION: ${{ matrix.desktop }}
+          ANDROID_MIN_VERSION: ${{ matrix.android }}
         run: |
           set -euo pipefail
           package="$RUNNER_TEMP/extension"
@@ -101,12 +143,17 @@ jobs:
           sed -i 's/^[[:space:]]*\/\/.*$//g' "$package/manifest.json"
           sed -i 's/{0a0f6dea-3957-4bb9-9eec-2ef2b9e5bcec}/{7c7f6dea-3957-4bb9-9eec-2ef2b9e5bcec}/g' "$package/manifest.json"
 
-          python3 - "$package/manifest.json" "${{ matrix.desktop }}" "${{ matrix.android }}" <<'PY'
-          import json, pathlib, sys
+          python3 - "$package/manifest.json" <<'PY'
+          import json, os, pathlib, re, sys
           path = pathlib.Path(sys.argv[1])
           manifest = json.loads(path.read_text(encoding="utf-8"))
-          manifest["browser_specific_settings"]["gecko"]["strict_min_version"] = sys.argv[2]
-          manifest["browser_specific_settings"]["gecko_android"]["strict_min_version"] = sys.argv[3]
+          desktop = os.environ["DESKTOP_MIN_VERSION"]
+          android = os.environ["ANDROID_MIN_VERSION"]
+          for platform, version in (("desktop", desktop), ("Android", android)):
+              if not re.fullmatch(r"\d+(?:\.\d+){0,2}", version):
+                  raise SystemExit(f"Invalid {platform} Firefox version: {version}")
+          manifest["browser_specific_settings"]["gecko"]["strict_min_version"] = desktop
+          manifest["browser_specific_settings"]["gecko_android"]["strict_min_version"] = android
           path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
           PY
 
@@ -116,7 +163,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          npx --yes web-ext@latest lint \
+          npx --yes web-ext@10.5.0 lint \
             --source-dir "$RUNNER_TEMP/extension" \
             --output json \
             > "$RUNNER_TEMP/${{ matrix.key }}-lint.json"
@@ -125,13 +172,15 @@ jobs:
 
       - name: Produce report
         shell: bash
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
         run: |
-          python3 - "$RUNNER_TEMP/${{ matrix.key }}-lint.json" "${{ matrix.name }}" <<'PY'
+          python3 - "$RUNNER_TEMP/${{ matrix.key }}-lint.json" <<'PY'
           import json, os, pathlib, sys
           data = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
           summary = data.get("summary", {})
           lines = [
-              f"## {sys.argv[2]}", "",
+              f"## {os.environ['MATRIX_NAME']}", "",
               f"- Errors: **{summary.get('errors', 0)}**",
               f"- Warnings: **{summary.get('warnings', 0)}**",
               f"- Notices: **{summary.get('notices', 0)}**",
@@ -168,31 +217,50 @@ jobs:
         run: |
           set -euo pipefail
           mkdir legacy target baseline
-          unzip -q artifacts/legacy-79-42-mozilla-lint/_temp/UltimaDark-legacy-79-42.zip -d legacy
-          unzip -q artifacts/desktop-115-mozilla-lint/_temp/UltimaDark-desktop-115.zip -d target
-          unzip -q artifacts/desktop-128-mozilla-lint/_temp/UltimaDark-desktop-128.zip -d baseline
+          unzip -q artifacts/legacy-mozilla-lint/_temp/UltimaDark-legacy.zip -d legacy
+          unzip -q artifacts/target-mozilla-lint/_temp/UltimaDark-target.zip -d target
+          unzip -q artifacts/baseline-mozilla-lint/_temp/UltimaDark-baseline.zip -d baseline
 
           python3 <<'PY'
-          import json, pathlib
-          roots = {"legacy": pathlib.Path("legacy"), "115": pathlib.Path("target"), "128": pathlib.Path("baseline")}
-          files = sorted(p.relative_to(roots["128"]) for p in roots["128"].rglob("*") if p.is_file())
+          import json, os, pathlib
+          roots = {"legacy": pathlib.Path("legacy"), "target": pathlib.Path("target"), "baseline": pathlib.Path("baseline")}
+          files = sorted(p.relative_to(roots["baseline"]) for p in roots["baseline"].rglob("*") if p.is_file())
           manifests = {}
           for name, root in roots.items():
               current = sorted(p.relative_to(root) for p in root.rglob("*") if p.is_file())
               assert current == files, f"file list differs for {name}"
               for rel in files:
                   if rel.as_posix() != "manifest.json":
-                      assert (root/rel).read_bytes() == (roots["128"]/rel).read_bytes(), f"unexpected difference: {name}/{rel}"
+                      assert (root/rel).read_bytes() == (roots["baseline"]/rel).read_bytes(), f"unexpected difference: {name}/{rel}"
               m = json.loads((root/"manifest.json").read_text())
               m["browser_specific_settings"]["gecko"].pop("strict_min_version")
               m["browser_specific_settings"]["gecko_android"].pop("strict_min_version")
               manifests[name] = m
-          assert manifests["legacy"] == manifests["115"] == manifests["128"], "manifests differ beyond minimum versions"
+          assert manifests["legacy"] == manifests["target"] == manifests["baseline"], "manifests differ beyond minimum versions"
 
           def summary(key):
               p = pathlib.Path(f"artifacts/{key}-mozilla-lint/_temp/{key}-lint.json")
               return json.loads(p.read_text()).get("summary", {})
-          for key in ("legacy-79-42", "desktop-115", "desktop-128"):
-              s = summary(key)
+          summaries = {key: summary(key) for key in ("legacy", "target", "baseline")}
+          for key, s in summaries.items():
               print(f"{key}: {s.get('errors',0)} errors, {s.get('warnings',0)} warnings, {s.get('notices',0)} notices")
+
+          regressions = [
+              kind for kind in ("errors", "warnings", "notices")
+              if summaries["target"].get(kind, 0) > summaries["baseline"].get(kind, 0)
+          ]
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as report:
+              report.write("## Target versus baseline\n\n")
+              report.write("| Configuration | Errors | Warnings | Notices |\n")
+              report.write("| --- | ---: | ---: | ---: |\n")
+              for key in ("legacy", "target", "baseline"):
+                  s = summaries[key]
+                  report.write(f"| {key} | {s.get('errors',0)} | {s.get('warnings',0)} | {s.get('notices',0)} |\n")
+              report.write("\n")
+              report.write(
+                  "Target has no more Mozilla findings than the baseline.\n"
+                  if not regressions else
+                  f"Target regressed in: {', '.join(regressions)}.\n"
+              )
+          assert not regressions, f"target has more findings than baseline: {', '.join(regressions)}"
           PY

--- a/.github/workflows/firefox-compatibility-audit.yml
+++ b/.github/workflows/firefox-compatibility-audit.yml
@@ -45,6 +45,7 @@ jobs:
           PY
 
       - name: Run Mozilla web-ext lint
+        continue-on-error: true
         run: |
           npx --yes web-ext@latest lint \
             --source-dir "$RUNNER_TEMP/extension" \


### PR DESCRIPTION
Adds a dedicated compatibility workflow for minimum-version changes.

It performs:

- Mozilla `web-ext lint` with desktop `strict_min_version` set independently to Firefox 115 and Firefox 128, while keeping Android at 128 so Android warnings do not contaminate the desktop comparison.
- A real package-loading smoke test in Firefox 115.18.0 ESR, with only the desktop minimum patched to 115.0.
- JSON and Markdown reports uploaded as workflow artifacts and concise job summaries.

This is intended to produce a reproducible answer for issue #216 and remain useful for future minimum-version decisions.